### PR TITLE
[Feat] 로그아웃 구현 및 알림 기능 초기화

### DIFF
--- a/WEB(FE)/ar/src/app/slice/AuthSlice.js
+++ b/WEB(FE)/ar/src/app/slice/AuthSlice.js
@@ -1,11 +1,14 @@
 import { createSlice } from '@reduxjs/toolkit';
-  
+import { PURGE } from 'redux-persist';
+
+const initialState = {
+    token: null,
+    isLoggedIn : false
+}
+
 const AuthSlice = createSlice({
     name : 'Auth',
-    initialState : {
-        token: null,
-        isLoggedIn : false
-    },
+    initialState,
     reducers : {
         login(state,action){
             state.token = action.payload;
@@ -20,6 +23,9 @@ const AuthSlice = createSlice({
         statevalue(state){
             return state;
         }
+    },
+    extraReducers: (builder) => {
+        builder.addCase(PURGE, () => initialState);
     }
 });
 

--- a/WEB(FE)/ar/src/app/slice/UserSlice.js
+++ b/WEB(FE)/ar/src/app/slice/UserSlice.js
@@ -1,25 +1,28 @@
 import { createSlice } from '@reduxjs/toolkit';
+import { PURGE } from 'redux-persist';
   
+const initialState = { 
+    UserObj: {
+        UserEmail: "", 
+        UserName: "", 
+        Classes: "", 
+        UserLocation: {
+            Crop : "",
+            Division : "",
+            Brigade : "",
+            Batalion : "",
+            Company : ""
+        },
+        UserLastDate : "",
+    },
+    uid : "",
+    isLocated: "",
+    isVacation : false,
+}
+
 const UserSlice = createSlice({
     name : 'User',
-    initialState : { 
-        UserObj: {
-            UserEmail: "", 
-            UserName: "", 
-            Classes: "", 
-            UserLocation: {
-                Crop : "",
-                Division : "",
-                Brigade : "",
-                Batalion : "",
-                Company : ""
-            },
-            UserLastDate : "",
-        },
-        uid : "",
-        isLocated: "",
-        isVacation : false,
-    },
+    initialState,
     reducers : {
         Creating(state,action){
             state.UserObj = action.payload;
@@ -40,6 +43,9 @@ const UserSlice = createSlice({
         IsVacation(state){
             return state.isVacation;
         }
+    },
+    extraReducers: (builder) => {
+        builder.addCase(PURGE, () => initialState);
     }
 });
 

--- a/WEB(FE)/ar/src/app/store/index.js
+++ b/WEB(FE)/ar/src/app/store/index.js
@@ -23,7 +23,7 @@ const store = configureStore({
   reducer: persistedReducer,
   middleware: (getDefaultMiddleware) => getDefaultMiddleware({
     serializableCheck: {
-      ignoreActions: [FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER]
+      ignoreActions: [FLUSH, REHYDRATE, PAUSE, PURGE, PERSIST, REGISTER]
     }
   })
 })

--- a/WEB(FE)/ar/src/components/base/Header.jsx
+++ b/WEB(FE)/ar/src/components/base/Header.jsx
@@ -2,14 +2,16 @@ import React, { useCallback, useRef } from 'react';
 import useHeader from './hooks/useHeader';
 import useToggle from '../../lib/hooks/uesToggle';
 import styled from 'styled-components'
+import { ToastContainer } from 'react-toastify';
 import HeaderLogo from './HeaderLogo'
 import HeaderMainMenu from './HeaderMainMenu'
 import HeaderUserIcon from './HeaderUserIcon'
 import HeaderUserMenu from './HeaderUserMenu'
 import HeaderNoticeIcon from './HeaderNoticeIcon'
+import HeaderNoticeCard from './HeaderNotifceCard';
 
 function Header() {
-  const { user } = useHeader();
+  const { user, onLogout } = useHeader();
   const [userMenu, toggleUserMenu] = useToggle(false);
   const ref = useRef(null);
 
@@ -25,6 +27,8 @@ function Header() {
     [toggleUserMenu]
   )
 
+  console.log(onLogout)
+
   return (
     <>
       <Block>
@@ -33,17 +37,20 @@ function Header() {
           <HeaderMainMenu user={user} />
 
           <HeaderNoticeIcon />
+          <HeaderNoticeCard user={user}/>
 
           <div ref={ref}>
             <HeaderUserIcon onClick={toggleUserMenu} />
           </div>
           <HeaderUserMenu
+            onLogout={onLogout}
             onClose={onOutesideClick}
             user={user}
             visible={userMenu}
           />
         </HeaderInner>
       </Block>
+      <ToastContainer />
     </>
   )
 }

--- a/WEB(FE)/ar/src/components/base/HeaderUserMenu.jsx
+++ b/WEB(FE)/ar/src/components/base/HeaderUserMenu.jsx
@@ -31,7 +31,6 @@ const HeaederUserMenu = ({
   visible
 }) => {
   if (!visible) return null;
-  console.log(user)
   return (
     <>
       <OutsideClickHandler>
@@ -45,6 +44,7 @@ const HeaederUserMenu = ({
             <p>전역일: </p>
             <p>위치:</p>
             <HeaderUserMenuItem to={`/@${user.uid}`}>정보</HeaderUserMenuItem>
+            <HeaderUserMenuItem onClick={onLogout}>로그아웃</HeaderUserMenuItem>
           </div>
         </HeaederUserMenuBlock>
       </OutsideClickHandler>

--- a/WEB(FE)/ar/src/components/base/hooks/useHeader.js
+++ b/WEB(FE)/ar/src/components/base/hooks/useHeader.js
@@ -1,8 +1,13 @@
 import { useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
+import { onMessage, onBackgroundMessage } from 'firebase/messaging'
+import { messaging } from '../../../database/message/messaging_init_in_sw'
+import { persistor } from '../../../app/store'
+import useThrottle from '../../../lib/hooks/useThrottle';
 
 export default function useHeader() {
   const dispath = useDispatch();
+  const timerRef = useThrottle();
   const userId = useSelector((state) => state.user.uid)
   const userData = useSelector((state) => state.user.UserObj)
   const user = {
@@ -10,14 +15,17 @@ export default function useHeader() {
     data: userData
   }
 
-  /* TODO: 마이프로필 드롭 메뉴중에서 logout시, 발생하는 이벤트 */
-  const onLogout = useCallback(async () => {
-  })
+  const onLogout = useCallback(async (timeout=500) => {
+    try {
+      if (user.uid) {
+        timerRef.throttle(async () => {
+          alert('로그아웃 되었습니다.');
+          await persistor.purge();
+          window.location.href = '/';
+        }, timeout)
+      }
+    } catch {}
+  });
 
-  /* TODO: 검색 아이콘 클릭시, 열리는 이벤트 */
-  const onSerachClick = useCallback(() => {
-
-  })
-
-  return { user }
+  return { user, onLogout }
 }

--- a/WEB(FE)/ar/src/components/base/hooks/usePushNotice.js
+++ b/WEB(FE)/ar/src/components/base/hooks/usePushNotice.js
@@ -1,0 +1,69 @@
+import { useRef } from 'react';
+import { toast } from 'react-toastify'
+import useThrottle from '../../../lib/hooks/useThrottle';
+
+const usePushNotice = () => {
+  const noticeRef = useRef(null);
+  const timerRef = useThrottle();
+
+  // Notification이 지원되지 않는 브라우저가 있을시
+  if (!Notification) {
+    toast.error(`
+      알림 기능이 지원되지 않는 브라우저 입니다. 
+      Chrome 브라우저 사용을 권장 드립니다!
+    `)
+    return;
+  }
+
+  if (Notification.permission !== 'granted') {
+    try {
+      Notification.requestPermission().then((permission) => {
+        if (permission !== 'granted') return;
+      })
+    } catch(err) {
+      if (err instanceof TypeError) {
+        Notification.requestPermission().then((permission) => {
+          if (permission !== 'granted') return;
+        })
+      } else {
+        console.error(err);
+      }
+    }
+  }
+
+  const setNoticeClickEvent = () => {
+    noticeRef.current.onclick = (event) => {
+      event.preventDefault();
+      window.focus();
+      noticeRef.current.close();
+    }
+  }
+  
+  const setNoticeTimer = (timeout) => {
+    timerRef.throttle(() => {
+      noticeRef.current.close();
+      noticeRef.current = null;
+    }, timeout);
+  }
+
+  const fireNoticeWithTimeout = (title, timeout, options = {}) => {
+    if (Notification.permission !== 'granted') return;
+
+    const newOption = {
+      badge: '',
+      icon: '',
+      ...options
+    }
+
+    if (!noticeRef.current) {
+      setNoticeTimer(timeout);      
+      noticeRef.current = new Notification(title, newOption)
+      setNoticeClickEvent();
+    }
+    
+  }
+
+  return { fireNoticeWithTimeout }
+}
+
+export default usePushNotice;

--- a/WEB(FE)/ar/src/database/DB_Manager.js
+++ b/WEB(FE)/ar/src/database/DB_Manager.js
@@ -19,7 +19,7 @@ const firebaseConfig = {
     measurementId: "G-X1NYBHGJBX"
 };
 
-const app = initializeApp(firebaseConfig);
+export const app = initializeApp(firebaseConfig);
 const db = getFirestore(app);
 
 export default db;

--- a/WEB(FE)/ar/src/database/message/messaging_init_in_sw.js
+++ b/WEB(FE)/ar/src/database/message/messaging_init_in_sw.js
@@ -1,0 +1,5 @@
+import { app } from '../DB_Manager'
+import { getMessaging } from 'firebase/messaging/sw'
+const messaging = getMessaging(app);
+
+export default messaging;

--- a/WEB(FE)/ar/src/lib/hooks/useThrottle.jsx
+++ b/WEB(FE)/ar/src/lib/hooks/useThrottle.jsx
@@ -1,0 +1,23 @@
+import { useRef } from 'react';
+
+const useThrottle = () => {
+  // timer를 저장하는 Ref를 하나 만든다. 
+  const timerRef = useRef(null);
+
+  const throttle = (callback, delay) => {
+    // 만약 timer가 없다면,
+    if (!timerRef.current) {
+      // 새로운 timer를 설정해준다.
+      timerRef.current = setTimeout(() => {
+        // delay time이 끝나면 callback을 실행한다.
+        callback();
+        // 다 실행하고 나면 timer를 초기화한다.
+        timerRef.current = null;
+      }, delay);
+    }
+  };
+
+  return { throttle };
+};
+
+export default useThrottle;


### PR DESCRIPTION
## Feat
- Hedaer의 UserMenu에서 수동으로 로그아웃이 가능합니다.
  - _로그아웃 함수가 실행되기 전 PURGE가 되면 안되므로, 비동기 처리와 Timer 처리를 함으로써 로그아웃 처리 후 초기화 하도록 구현_ 

## Chore
- Header의 `<HeaderNotice>` 컴포넌트를 활성화 하기 위해 훅을 만들어 놓았으나... PC 문제인지 Notification이 Background에서 보이지 않음.
  - _그래서 알림기능을 Fire cloud messaging으로 구현하려고 생각중입니다._ @Sunja-An 

---

### [Q] 백엔드를 구현해야할지 의문이 듭니다.
- 현재 파이어베이스를 통해 Auth, Database 등을 쉽게 구현하고 있습니다.
- 백엔드 서비스를 빠르게 구축한다는 것은 좋지만 데이터 송수신이 어떻게 되고 있는지 바로바로 알 수가 없어 불편함이 좀 있는거 같습니다.
- 자문을 좀 구하고 싶습니다.